### PR TITLE
Fix pip setup and pin dependency versions

### DIFF
--- a/docs/install.rst
+++ b/docs/install.rst
@@ -46,6 +46,34 @@ following command in the same directory as the two previous one:
 .. _Vagrant: https://www.vagrantup.com/downloads.html
 .. _Virtualbox: https://www.virtualbox.org/wiki/Downloads
 
+Manual installation from PyPI
+-----------------------------
+
+You can download and install IPMininet.
+If you have pip above **18.1**, execute:
+
+.. code-block:: bash
+
+    $ sudo pip install ipmininet
+
+If you have an older version of pip, use:
+
+.. code-block:: bash
+
+    $ sudo pip install --process-dependency-links ipmininet
+
+Then, you can install all the daemons:
+
+.. code-block:: bash
+
+    $ sudo python -m ipmininet.install -af
+
+You can choose to install only a subset of the daemons
+by changing the options on the installation script.
+For the option documentations, use the ``-h`` option.
+
+.. _documentation: http://mininet.org/download/
+
 Manual installation from sources
 --------------------------------
 
@@ -57,35 +85,25 @@ To manually install IPMininet from source, first get the source code:
     $ cd ipmininet
     $ git checkout <version>
 
-Then, install IPMininet, Mininet and all the daemons:
+Then, install IPMininet.
+If you have pip above **18.1**, execute:
 
 .. code-block:: bash
 
-    $ sudo python util/install.py -iamf
+    $ sudo pip install .
 
-You can choose to install only a subset of the daemons
-by changing the options on the installation script.
-For the option documentations, use the ``-h`` option.
-
-Manual installation from PyPI
------------------------------
-
-Install Mininet by following its `documentation`_.
-
-Then, you can download and install IPMininet.
+If you have an older version of pip, use:
 
 .. code-block:: bash
 
-    $ sudo pip install ipmininet
+    $ sudo pip install --process-dependency-links .
 
 Finally, you can install all the daemons:
 
 .. code-block:: bash
 
-    $ sudo python util/install.py -af
+    $ sudo python -m ipmininet.install -af
 
 You can choose to install only a subset of the daemons
 by changing the options on the installation script.
 For the option documentations, use the ``-h`` option.
-
-.. _documentation: http://mininet.org/download/

--- a/ipmininet/install/__main__.py
+++ b/ipmininet/install/__main__.py
@@ -1,0 +1,56 @@
+from .install import *
+
+
+if __name__ == "__main__":
+
+    args = parse_args()
+    args.output_dir = os.path.normpath(os.path.abspath(args.output_dir))
+
+    dist.require_pip(2)
+    dist.require_pip(3)
+
+    if args.install_mininet:
+        install_mininet(args.output_dir)
+
+    if args.all or args.install_frrouting:
+        install_frrouting(args.output_dir)
+
+    if args.all or args.install_radvd:
+        if dist.NAME == "Ubuntu" or dist.NAME == "Debian":
+            dist.install("resolvconf")
+        dist.install("radvd")
+
+    if args.all or args.install_sshd:
+        dist.install("openssh-server")
+
+    # Install IPMininet
+
+    if args.install_ipmininet:
+        dist.install("git")
+        ipmininet_folder = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+        dist.pip_install(2, ipmininet_folder)
+        dist.pip_install(3, ipmininet_folder)
+
+    # Enable IPv6 (disabled by mininet installation)
+
+    if args.all or args.enable_ipv6:
+        enable_ipv6()
+
+    # Install test dependencies
+
+    dist.install("bridge-utils", "traceroute")
+    if dist.NAME == "Fedora":
+        dist.install("nc")
+    else:
+        dist.install("netcat-openbsd")
+
+    dist.pip_install(2, "pytest")
+    dist.pip_install(3, "pytest")
+
+    # Install OpenR
+
+    if args.install_openr:
+        if dist.NAME == "Ubuntu":
+            install_openr(args.output_dir)
+        else:
+            print("OpenR build currently only available on Ubuntu. Skipping installing OpenR.")

--- a/ipmininet/install/build_vm.sh
+++ b/ipmininet/install/build_vm.sh
@@ -7,7 +7,7 @@ set -e
 
 export LC_ALL=C
 
-MN_VERSION="master"
+MN_VERSION="2.3.0d6"
 MN_INSTALL_SCRIPT_REMOTE="https://raw.githubusercontent.com/mininet/mininet/${MN_VERSION}/util/vm/install-mininet-vm.sh"
 DEPS="python \
       python-pip \
@@ -25,21 +25,17 @@ sudo sed -i -e 's/^\(127\.0\.1\.1\).*/\1\tmininet-vm/' /etc/hosts
 # Install mininet
 pushd $HOME
 source <(curl -sL ${MN_INSTALL_SCRIPT_REMOTE})
-sudo pip2 install mininet/
-sudo pip3 install mininet/
+
+# Update pip install
+sudo pip3 install --upgrade pip
+sudo pip2 install --upgrade pip
+sudo apt remove -yq python-pip python3-pip
 
 # Install ipmininet
 git clone https://github.com/cnp3/ipmininet.git
 pushd ipmininet
-sudo python3 util/install.py -iaf
+sudo pip2 install .
+sudo pip3 install .
+sudo python3 ipmininet/install/install.py -af
 popd
 popd
-
-# Fix setuptools version issue
-sudo pip2 install --upgrade pip
-sudo apt-get remove -y python-pip
-sudo pip2 install --upgrade setuptools
-
-sudo pip3 install --upgrade pip
-sudo apt-get remove -y python3-pip
-sudo pip3 install --upgrade setuptools

--- a/ipmininet/install/install.py
+++ b/ipmininet/install/install.py
@@ -1,12 +1,12 @@
 import argparse
 import os
-import sys
-import stat
 import re
+import stat
+import sys
 
-from utils import supported_distributions, identify_distribution, sh
+from .utils import supported_distributions, identify_distribution, sh
 
-MininetVersion = "master"
+MininetVersion = "2.3.0d6"
 FRRoutingVersion = "7.1"
 OpenrRelease = "rc-20190419-11514"
 
@@ -34,7 +34,7 @@ def parse_args():
     return parser.parse_args()
 
 
-def install_mininet():
+def install_mininet(output_dir, pip_install=True):
     dist.install("git")
 
     if dist.NAME == "Fedora":
@@ -45,15 +45,17 @@ def install_mininet():
     else:
         mininet_opts = "-a"
 
-    sh("git clone https://github.com/mininet/mininet.git", cwd=args.output_dir)
-    sh("git checkout %s" % MininetVersion, cwd=os.path.join(args.output_dir, "mininet"))
+    sh("git clone https://github.com/mininet/mininet.git", cwd=output_dir)
+    sh("git checkout %s" % MininetVersion, cwd=os.path.join(output_dir, "mininet"))
     sh("mininet/util/install.sh %s -s ." % mininet_opts,
-       "pip2 -q install mininet/",
-       "pip3 -q install mininet/",
-       cwd=args.output_dir)
+       cwd=output_dir)
+
+    if pip_install:
+        dist.pip_install(2, "mininet/", cwd=output_dir)
+        dist.pip_install(3, "mininet/", cwd=output_dir)
 
 
-def install_libyang():
+def install_libyang(output_dir):
 
     packages = []
 
@@ -78,10 +80,10 @@ def install_libyang():
         sh("wget %s/%s" % (libyang_url, package),
            "%s %s" % (cmd, package),
            "rm %s" % package,
-           cwd=args.output_dir)
+           cwd=output_dir)
 
 
-def install_frrouting():
+def install_frrouting(output_dir):
     dist.install("autoconf", "automake", "libtool", "make", "gcc", "groff",
                  "patch", "make", "bison", "flex", "gawk",
                  "python3-pytest")
@@ -95,15 +97,15 @@ def install_frrouting():
                      "perl-core", "python3-devel", "pam-devel", "systemd-devel",
                      "net-snmp-devel", "pkgconfig")
 
-    install_libyang()
+    install_libyang(output_dir)
 
-    frrouting_src = os.path.join(args.output_dir, "frr-%s" % FRRoutingVersion)
+    frrouting_src = os.path.join(output_dir, "frr-%s" % FRRoutingVersion)
     frrouting_tar = frrouting_src + ".tar.gz"
     sh("wget https://github.com/FRRouting/frr/releases/download/frr-{v}/frr-{v}.tar.gz".format(v=FRRoutingVersion),
        "tar -zxvf '%s'" % frrouting_tar,
-       cwd=args.output_dir)
+       cwd=output_dir)
 
-    frrouting_install = os.path.join(args.output_dir, "frr")
+    frrouting_install = os.path.join(output_dir, "frr")
     sh("./configure '--prefix=%s'" % frrouting_install,
        "make",
        "make install",
@@ -132,15 +134,15 @@ def install_frrouting():
         break
 
 
-def install_openr(openr_release=OpenrRelease,
+def install_openr(output_dir, openr_release=OpenrRelease,
                   openr_remote="https://github.com/facebook/openr.git"):
     dist.install("git")
-    openr_install = os.path.join(args.output_dir, "openr")
+    openr_install = os.path.join(output_dir, "openr")
     openr_build = os.path.join(openr_install, "build")
     openr_buildscript = os.path.join(openr_build, "build_openr_debian.sh")
     debian_system_builder = "debian_system_builder/debian_system_builder.py"
     sh("git clone %s" % openr_remote,
-       cwd=args.output_dir)
+       cwd=output_dir)
     sh("git checkout %s" % openr_release,
        cwd=openr_install)
     # Generate build script
@@ -187,8 +189,7 @@ def enable_ipv6():
     sh("sysctl -p")
 
 
-args = parse_args()
-args.output_dir = os.path.normpath(os.path.abspath(args.output_dir))
+# Force root
 
 if os.getuid() != 0:
     print("This program must be run as root")
@@ -201,53 +202,3 @@ if dist is None:
     print("The installation script only supports %s" % ", ".join([d.NAME for d in supported_distributions()]))
     sys.exit(1)
 dist.update()
-
-# Install dependencies
-
-dist.install("python-pip", "python3-pip")
-
-if args.install_mininet:
-    install_mininet()
-
-if args.all or args.install_frrouting:
-    install_frrouting()
-
-if args.all or args.install_radvd:
-    if dist.NAME == "Ubuntu" or dist.NAME == "Debian":
-        dist.install("resolvconf")
-    dist.install("radvd")
-
-if args.all or args.install_sshd:
-    dist.install("openssh-server")
-
-# Install IPMininet
-
-if args.install_ipmininet:
-    ipmininet_folder = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
-    sh("pip2 -q install %s/" % ipmininet_folder)
-    sh("pip3 -q install %s/" % ipmininet_folder)
-
-# Enable IPv6 (disabled by mininet installation)
-
-if args.all or args.enable_ipv6:
-    enable_ipv6()
-
-# Install test dependencies
-
-dist.install("bridge-utils", "traceroute")
-if dist.NAME == "Fedora":
-    dist.install("nc")
-else:
-    dist.install("netcat-openbsd")
-
-sh("pip2 -q install pytest")
-sh("pip3 -q install pytest")
-
-# Install OpenR
-
-if args.install_openr:
-    if dist.NAME == "Ubuntu":
-        install_openr()
-    else:
-        print("OpenR build currently only available on Ubuntu. Skipping installing OpenR.")
-        pass

--- a/ipmininet/link.py
+++ b/ipmininet/link.py
@@ -297,10 +297,18 @@ def address_comparator(a, b):
         return 1
     if b.network.is_global and not a.network.is_global:
         return -1
-    # Otherwise simply rank the IP values
-    if a > b:
+    # Compare networks
+    if b.network.is_global and not a.network.is_global:
+        return -1
+    # Compare network values
+    if a.network < b.network:
+        return -1
+    if a.network > b.network:
         return 1
-    return -1 if b > a else 0
+    # Otherwise simply rank the IP values
+    if a.ip < b.ip:
+        return -1
+    return 1 if a.ip > b.ip else 0
 
 
 class PhysicalInterface(IPIntf):

--- a/ipmininet/tests/test_cli.py
+++ b/ipmininet/tests/test_cli.py
@@ -36,10 +36,10 @@ def net(request):
 
 
 @pytest.fixture(scope="function")
-def tmp():
+def tmp(request):
     name = tempfile.mktemp()
-    yield name
-    os.unlink(name)
+    request.addfinalizer(lambda: os.unlink(name))
+    return name
 
 
 def perm(*args):

--- a/ipmininet/tests/test_link.py
+++ b/ipmininet/tests/test_link.py
@@ -21,6 +21,10 @@ from ipmininet.tests import require_root
      [u"100.64.0.1/32", u"10.0.0.1/8"]),  # Public before private
     ([u"100.64.0.1/32", u"10.0.0.1/8"],
      [u"100.64.0.1/32", u"10.0.0.1/8"]),  # Public before private
+    ([u"2001::1/16", u"2002::1/16"],
+     [u"2002::1/16", u"2001::1/16"]),  # Bigger network value first
+    ([u"2002::1/16", u"2001::1/16"],
+     [u"2002::1/16", u"2001::1/16"]),  # Bigger network value first
     ([u"2001::1/16", u"2001::2/16"],
      [u"2001::2/16", u"2001::1/16"]),  # Bigger IP value first
     ([u"2001::2/16", u"2001::1/16"],


### PR DESCRIPTION
This implies changes in the install scripts: they are moved inside
the ipmininet library so that they can be used by the `setup.py` file.
The documentation is also updated.